### PR TITLE
Update dependency ncc, typescript and TS-Types

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -45,11 +45,11 @@
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",
     "@types/async": "^3.2.5",
-    "@types/fs-extra": "^9.0.4",
+    "@types/fs-extra": "^9.0.6",
     "@types/n-readlines": "^1.0.1",
-    "@types/node": "~12.19.8",
-    "@vercel/ncc": "^0.25.1",
+    "@vercel/ncc": "^0.26.1",
+    "@types/node": "~12.19.11",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       "dev": true
     },
     "@vercel/ncc": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.25.1.tgz",
-      "integrity": "sha512-dGecC5+1wLof1MQpey4+6i2KZv4Sfs6WfXkl9KfO32GED4ZPiKxRfvtGPjbjZv0IbqMl6CxtcV1RotXYfd5SSA==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.26.1.tgz",
+      "integrity": "sha512-iVhYAL/rpHgjO88GkDHNVNrp7WTfMFBbeWXNgwaDPMv5rDI4hNOAM0u+Zhtbs42XBQE6EccNaY6UDb/tm1+dhg==",
       "dev": true
     },
     "arg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,9 +164,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.4.tgz",
-      "integrity": "sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.6.tgz",
+      "integrity": "sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
       }
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
+      "version": "12.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.11.tgz",
+      "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
       "dev": true
     },
     "@vercel/ncc": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/fs-extra": "^9.0.4",
     "@types/n-readlines": "^1.0.1",
     "@types/node": "~12.19.8",
-    "@vercel/ncc": "^0.25.1",
+    "@vercel/ncc": "^0.26.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "@types/async": "^3.2.5",
     "@types/fs-extra": "^9.0.4",
     "@types/n-readlines": "^1.0.1",
-    "@types/node": "~12.19.8",
     "@vercel/ncc": "^0.26.1",
+    "@types/node": "~12.19.11",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",
     "@types/async": "^3.2.5",
-    "@types/fs-extra": "^9.0.4",
+    "@types/fs-extra": "^9.0.6",
     "@types/n-readlines": "^1.0.1",
     "@vercel/ncc": "^0.26.1",
     "@types/node": "~12.19.11",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "@types/node": "~12.19.8",
     "@vercel/ncc": "^0.26.1",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   }
 }


### PR DESCRIPTION
* *typescript* from `4.1.2` to `4.1.3`
* *@vercel/ncc* from `0.25.1` to `0.26.1`
* *@types/node* from `12.19.8` to `12.19.11`
* *@types/fs-extra* from `9.0.4` to `9.0.6`